### PR TITLE
fix: 조회수, 게시물 수정시간 같이 업데이트 되는부분 수정

### DIFF
--- a/server/src/main/java/server/question/repository/QuestionRepository.java
+++ b/server/src/main/java/server/question/repository/QuestionRepository.java
@@ -1,7 +1,13 @@
 package server.question.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import server.question.entity.Question;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
+    @Modifying
+    @Query("update Question q set q.views = :views where q.questionId = :questionId")
+    int updateViews(@Param("views") int views, @Param("questionId") long questionId);
 }

--- a/server/src/main/java/server/question/service/QuestionService.java
+++ b/server/src/main/java/server/question/service/QuestionService.java
@@ -4,14 +4,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
-import server.answer.entity.Answer;
 import server.question.entity.Question;
 import server.question.repository.QuestionRepository;
 
+import javax.transaction.Transactional;
 import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class QuestionService {
 
     private final QuestionRepository questionRepository;
@@ -46,9 +47,10 @@ public class QuestionService {
         return question.orElseThrow(Exception::new);
     }
 
-    public void updateViews(long questionId, int views) throws Exception {
-        Question findQuestion = findVerifiedQuestion(questionId);
-        findQuestion.setViews(views);
-        questionRepository.save(findQuestion);
+    public void updateViews(long questionId, int views) {
+        questionRepository.updateViews(views, questionId);
+//        Question findQuestion = findVerifiedQuestion(questionId);
+//        findQuestion.setViews(views);
+//        questionRepository.save(findQuestion);
     }
 }


### PR DESCRIPTION
### Summary
조회수 업데이트시 게시물이 수정된걸로 처리되어 시간이 변경되는 버그 수정.


### Key Changes 
- 엔티티 세팅이 아닌 직접 쿼리를 날려서 적용


### To Reviewers
새벽에 눌러보다 갑자기 발견했습니다..


### Issue number
관련 이슈 #97 
