### PR TITLE
feat: UserInfo answers & comments 조회 기능 구현

### DIFF
--- a/server/src/main/java/server/answer/controller/AnswerController.java
+++ b/server/src/main/java/server/answer/controller/AnswerController.java
@@ -82,4 +82,6 @@ public class AnswerController {
         Answer answer = answerService.findVerifiedAnswer(answerId);
         return new ResponseEntity(answerMapper.answerToAnswerResponseDto(answer, userMapper, commentService), HttpStatus.OK);
     }
+
+
 }

--- a/server/src/main/java/server/answer/dto/AnswerUserResponseDto.java
+++ b/server/src/main/java/server/answer/dto/AnswerUserResponseDto.java
@@ -1,0 +1,15 @@
+package server.answer.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class AnswerUserResponseDto {
+    private long questionId;
+    private String questionContent;
+    private String subCategory;
+    private LocalDateTime answerCreatedAt;
+}

--- a/server/src/main/java/server/answer/mapper/AnswerMapper.java
+++ b/server/src/main/java/server/answer/mapper/AnswerMapper.java
@@ -3,10 +3,9 @@ package server.answer.mapper;
 import org.mapstruct.Mapper;
 import server.answer.dto.AnswerPostPutDto;
 import server.answer.dto.AnswerResponseDto;
+import server.answer.dto.AnswerUserResponseDto;
 import server.answer.entity.Answer;
 import server.comment.service.CommentService;
-import server.question.dto.QuestionsResponseDto;
-import server.question.entity.Question;
 import server.user.mapper.UserMapper;
 
 import java.util.ArrayList;
@@ -49,5 +48,29 @@ public interface AnswerMapper {
         answerResponseDto.setComments(commentService.findComments(answer, userMapper));
 
         return answerResponseDto;
+    }
+
+    default AnswerUserResponseDto answerToAnswerUserResponseDto(Answer answer) {
+        AnswerUserResponseDto answeruserResponseDto = new AnswerUserResponseDto();
+
+        answeruserResponseDto.setQuestionId(answer.getQuestion().getQuestionId());
+        answeruserResponseDto.setQuestionContent(answer.getQuestion().getContent());
+        answeruserResponseDto.setSubCategory(answer.getQuestion().getSubCategory());
+        answeruserResponseDto.setAnswerCreatedAt(answer.getCreatedAt());
+
+        return answeruserResponseDto;
+    }
+
+    default List<AnswerUserResponseDto> answersToAnswerUserResponseDtos(List<Answer> answers) {
+        if ( answers == null ) {
+            return null;
+        }
+
+        List<AnswerUserResponseDto> list = new ArrayList<>(answers.size());
+        for ( Answer answer : answers ) {
+            list.add( answerToAnswerUserResponseDto( answer) );
+        }
+
+        return list;
     }
 }

--- a/server/src/main/java/server/answer/repository/AnswerRepository.java
+++ b/server/src/main/java/server/answer/repository/AnswerRepository.java
@@ -8,10 +8,12 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import server.answer.entity.Answer;
 import server.question.entity.Question;
+import server.user.entity.User;
 
 
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
     Page<Answer> findAllByQuestion(Question question, Pageable pageable);
+    Page<Answer> findAllByUser(User user, Pageable pageable);
 
     @Modifying
     @Query("update Answer a set a.votes = :votes where a.answerId = :answerId")

--- a/server/src/main/java/server/answer/service/AnswerService.java
+++ b/server/src/main/java/server/answer/service/AnswerService.java
@@ -5,12 +5,14 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import server.answer.dto.AnswerResponseDto;
+import server.answer.dto.AnswerUserResponseDto;
 import server.answer.entity.Answer;
 import server.answer.mapper.AnswerMapper;
 import server.answer.repository.AnswerRepository;
 import server.comment.service.CommentService;
 import server.question.entity.Question;
 import server.response.MultiResponseDto;
+import server.user.entity.User;
 import server.user.mapper.UserMapper;
 
 import java.util.List;
@@ -60,4 +62,13 @@ public class AnswerService {
         return new MultiResponseDto<>(answerMapper.AnswersToAnswersResponseDtos(answers, userMapper, commentService), pageAnswers);
 
     }
+
+    public MultiResponseDto<AnswerUserResponseDto> userInfoAnswers(User user,
+                                                                   int page, int size) {
+        Page<Answer> pageAnswers = answerRepository.findAllByUser(user, PageRequest.of(page-1, size));
+        List<Answer> answers = pageAnswers.getContent();
+        return new MultiResponseDto<>(answerMapper.answersToAnswerUserResponseDtos(answers), pageAnswers);
+    }
+
+
 }

--- a/server/src/main/java/server/comment/dto/CommentUserResponseDto.java
+++ b/server/src/main/java/server/comment/dto/CommentUserResponseDto.java
@@ -1,0 +1,15 @@
+package server.comment.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class CommentUserResponseDto {
+    private long questionId;
+    private String questionContent;
+    private String subCategory;
+    private LocalDateTime commentCreatedAt;
+}

--- a/server/src/main/java/server/comment/mapper/CommentMapper.java
+++ b/server/src/main/java/server/comment/mapper/CommentMapper.java
@@ -1,10 +1,16 @@
 package server.comment.mapper;
 
 import org.mapstruct.Mapper;
+import server.answer.dto.AnswerUserResponseDto;
+import server.answer.entity.Answer;
 import server.comment.dto.CommentPostPutDto;
 import server.comment.dto.CommentResponseDto;
+import server.comment.dto.CommentUserResponseDto;
 import server.comment.entity.Comment;
 import server.user.mapper.UserMapper;
+
+import java.util.ArrayList;
+import java.util.List;
 
 
 @Mapper(componentModel = "spring")
@@ -24,4 +30,27 @@ public interface CommentMapper {
         return commentResponseDto;
     }
 
+    default CommentUserResponseDto commentToCommentUserResponseDto(Comment comment) {
+        CommentUserResponseDto commentUserResponseDto = new CommentUserResponseDto();
+
+        commentUserResponseDto.setQuestionId(comment.getAnswer().getQuestion().getQuestionId());
+        commentUserResponseDto.setQuestionContent(comment.getAnswer().getQuestion().getContent());
+        commentUserResponseDto.setSubCategory(comment.getAnswer().getQuestion().getSubCategory());
+        commentUserResponseDto.setCommentCreatedAt(comment.getCreatedAt());
+
+        return commentUserResponseDto;
+    }
+
+    default List<CommentUserResponseDto> commentsToCommentUserResponseDtos(List<Comment> comments) {
+        if ( comments == null ) {
+            return null;
+        }
+
+        List<CommentUserResponseDto> list = new ArrayList<>(comments.size());
+        for ( Comment comment : comments ) {
+            list.add( commentToCommentUserResponseDto( comment) );
+        }
+
+        return list;
+    }
 }

--- a/server/src/main/java/server/comment/repository/CommentRepository.java
+++ b/server/src/main/java/server/comment/repository/CommentRepository.java
@@ -1,12 +1,17 @@
 package server.comment.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import server.answer.entity.Answer;
 import server.comment.entity.Comment;
+import server.user.entity.User;
 
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     List<Comment> findAllByAnswer(Answer answer);
+    Page<Comment> findAllByUser(User user, Pageable pageable);
+
 }

--- a/server/src/main/java/server/comment/service/CommentService.java
+++ b/server/src/main/java/server/comment/service/CommentService.java
@@ -2,12 +2,16 @@ package server.comment.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import server.answer.entity.Answer;
 import server.comment.dto.CommentResponseDto;
+import server.comment.dto.CommentUserResponseDto;
 import server.comment.entity.Comment;
 import server.comment.mapper.CommentMapper;
 import server.comment.repository.CommentRepository;
+import server.response.MultiResponseDto;
+import server.user.entity.User;
 import server.user.mapper.UserMapper;
 
 import java.util.ArrayList;
@@ -50,5 +54,12 @@ public class CommentService {
             commentResponseDtos.add(commentMapper.commentToCommentResponseDto(comment, userMapper));
         }
         return commentResponseDtos;
+    }
+
+    public MultiResponseDto<CommentUserResponseDto> userInfoComments(User user,
+                                                                     int page, int size) {
+        Page<Comment> pageComments = commentRepository.findAllByUser(user, PageRequest.of(page-1, size));
+        List<Comment> comments = pageComments.getContent();
+        return new MultiResponseDto<>(commentMapper.commentsToCommentUserResponseDtos(comments), pageComments);
     }
 }

--- a/server/src/main/java/server/question/controller/QuestionController.java
+++ b/server/src/main/java/server/question/controller/QuestionController.java
@@ -1,5 +1,6 @@
 package server.question.controller;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;

--- a/server/src/main/java/server/question/mapper/QuestionMapper.java
+++ b/server/src/main/java/server/question/mapper/QuestionMapper.java
@@ -7,11 +7,9 @@ import server.question.dto.QuestionPostPutDto;
 import server.question.dto.QuestionResponseDto;
 import server.question.dto.QuestionsResponseDto;
 import server.question.entity.Question;
-import server.user.dto.UserProfileResponseDto;
 import server.user.mapper.UserMapper;
 
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;

--- a/server/src/main/java/server/user/controller/UserController.java
+++ b/server/src/main/java/server/user/controller/UserController.java
@@ -4,10 +4,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import server.answer.service.AnswerService;
+import server.comment.service.CommentService;
 import server.user.dto.PasswordDto;
 import server.user.dto.UserPostDto;
 import server.user.dto.UserPutDto;
@@ -17,6 +18,7 @@ import server.user.service.UserService;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Positive;
+
 @Validated
 @RequiredArgsConstructor
 @RestController
@@ -25,6 +27,10 @@ public class UserController {
 
     private final UserService userService;
     private final UserMapper userMapper;
+
+    private final AnswerService answerService;
+
+    private final CommentService commentService;
 
     @PostMapping
     public ResponseEntity join(@Valid @RequestBody UserPostDto userPostDto) throws Exception {
@@ -66,5 +72,26 @@ public class UserController {
         userService.updatePassword(email, passwordDto.getCurPassword(), passwordDto.getNewPassword());
 
         return new ResponseEntity("비밀번호 변경이 완료되었습니다.", HttpStatus.OK);
+    }
+
+    // UserInfo Page Answers
+    @GetMapping("/{user-id}/answers")
+    public ResponseEntity UserInfoAnswers(@Positive @PathVariable("user-id") long userId,
+                                          @Positive @RequestParam int page,
+                                          @Positive @RequestParam int size
+                                          ) throws Exception {
+        User findUser = userService.findUserById(userId);
+        return new ResponseEntity(userMapper.userToUserAnswersResponseDto(findUser, page, size, answerService), HttpStatus.OK);
+    }
+
+
+
+    // UserInfo Page Comments
+    @GetMapping("/{user-id}/comments")
+    public ResponseEntity UserInfoComments(@Positive @PathVariable("user-id") long userId,
+                                           @Positive @RequestParam int page,
+                                           @Positive @RequestParam int size) throws Exception {
+        User findUser = userService.findUserById(userId);
+        return new ResponseEntity(userMapper.userToUserCommentsResponseDto(findUser, page, size, commentService), HttpStatus.OK);
     }
 }

--- a/server/src/main/java/server/user/dto/UserAnswersResponseDto.java
+++ b/server/src/main/java/server/user/dto/UserAnswersResponseDto.java
@@ -1,0 +1,12 @@
+package server.user.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import server.answer.dto.AnswerUserResponseDto;
+import server.response.MultiResponseDto;
+
+@Setter
+@Getter
+public class UserAnswersResponseDto {
+    private MultiResponseDto<AnswerUserResponseDto> answers;
+}

--- a/server/src/main/java/server/user/dto/UserCommentsResponseDto.java
+++ b/server/src/main/java/server/user/dto/UserCommentsResponseDto.java
@@ -1,0 +1,12 @@
+package server.user.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import server.comment.dto.CommentUserResponseDto;
+import server.response.MultiResponseDto;
+
+@Setter
+@Getter
+public class UserCommentsResponseDto {
+    private MultiResponseDto<CommentUserResponseDto> comments;
+}

--- a/server/src/main/java/server/user/dto/UserResponseDto.java
+++ b/server/src/main/java/server/user/dto/UserResponseDto.java
@@ -13,7 +13,4 @@ public class UserResponseDto {
     private String nickname;
     private String profile;
     private String status;
-//    private List<QuestionResponseDto> questions;
-//    private List<AnswerResponseDto> answers;
-//    private List<CommentResponseDto> comments;
 }

--- a/server/src/main/java/server/user/mapper/UserMapper.java
+++ b/server/src/main/java/server/user/mapper/UserMapper.java
@@ -1,10 +1,9 @@
 package server.user.mapper;
 
 import org.mapstruct.Mapper;
-import server.user.dto.UserPostDto;
-import server.user.dto.UserProfileResponseDto;
-import server.user.dto.UserPutDto;
-import server.user.dto.UserResponseDto;
+import server.answer.service.AnswerService;
+import server.comment.service.CommentService;
+import server.user.dto.*;
 import server.user.entity.User;
 
 @Mapper(componentModel = "spring")
@@ -20,6 +19,24 @@ public interface UserMapper {
         userProfileResponseDto.setNickname(user.getNickname());
         userProfileResponseDto.setStatus(user.getUserStatus().getStatus());
         return userProfileResponseDto;
+    }
+
+    default UserAnswersResponseDto userToUserAnswersResponseDto(User user,
+                                                                int page,
+                                                                int size,
+                                                                AnswerService answerService) {
+        UserAnswersResponseDto userAnswersResponseDto = new UserAnswersResponseDto();
+        userAnswersResponseDto.setAnswers(answerService.userInfoAnswers(user, page, size));
+        return userAnswersResponseDto;
+    }
+
+    default UserCommentsResponseDto userToUserCommentsResponseDto(User user,
+                                                                int page,
+                                                                int size,
+                                                                CommentService commentService) {
+        UserCommentsResponseDto userCommentsResponseDto = new UserCommentsResponseDto();
+        userCommentsResponseDto.setComments(commentService.userInfoComments(user, page, size));
+        return userCommentsResponseDto;
     }
 
 }

--- a/server/src/main/java/server/user/service/UserService.java
+++ b/server/src/main/java/server/user/service/UserService.java
@@ -79,6 +79,7 @@ public class UserService {
 //        userRepository.delete(findUser);
     }
 
+
     private User findVerifiedUser(long userId) throws Exception {
         Optional<User> user = userRepository.findById(userId);
         return user.orElseThrow(Exception::new);
@@ -100,5 +101,4 @@ public class UserService {
         if (user.isPresent())
             throw new BusinessLogicException(ExceptionCode.DUPLICATE_NICKNAME);
     }
-
 }


### PR DESCRIPTION
### Summary
UserInfo answers & comments 조회 기능 구현하였습니다.

### Key Changes 
- 유저 페이지 조회 시 사용할 answers 구현
- 유저 페이지 조회 시 사용할 comments 구현


### To Reviewers
`super.doFilterInternal(request, response, chain);` 코드를 주석처리하지 않으면 반환이 2번 됩니다.. 
다른 조회 메서드랑 비교하면 토큰 필요 유무 차이가 있는 것 같습니다.
유저페이지 조회같은 경우는 로그인이 필요하지 않은 서비스이기 때문에 제외해도 좋을 것 같습니다.
그런데 이전에 이 코드를 주석처리하고 안하고의 차이를 궁금해하셨던 것 같아서 이번 기회에 확인해보시면 좋을 것 같아요!
api 문서는 이 문제가 해결되고 나서 수정하겠습니다:)

### Issue number
#116 
