### PR TITLE
fix: deploy.sh 킬-실행 sleep 늘림

### DIFF
--- a/server/scripts/deploy.sh
+++ b/server/scripts/deploy.sh
@@ -19,7 +19,7 @@ then
 else
   echo "> kill -15 $CURRENT_PID" >> /home/ubuntu/action/deploy.log
   sudo kill -15 $CURRENT_PID
-  sleep 5
+  sleep 10
 fi
 
 


### PR DESCRIPTION
### Summary
프로세스 킬 후 실행 텀이 짧은거같아서 변경했습니다.