### PR TITLE
메인 페이지 질문 조회 시 카테고리 필터링 및 정렬 방법 변경

### DIFF
--- a/server/src/main/java/server/question/controller/QuestionController.java
+++ b/server/src/main/java/server/question/controller/QuestionController.java
@@ -101,7 +101,7 @@ public class QuestionController {
     @GetMapping("/tags")
     @Transactional(readOnly = true)
     public ResponseEntity<MultiResponseDto<QuestionsResponseDto>> getQuestionsByCategory(@RequestParam String mainCategory,
-                                                                                         @RequestParam(required = false) String subCategory,
+                                                                                         @RequestParam String subCategory,
                                                                                          @Positive @RequestParam int page,
                                                                                          @Positive @RequestParam int size) {
         Page<Question> pageQuestions = questionService.findQuestionsByCategory(mainCategory, subCategory, page - 1, size);

--- a/server/src/main/java/server/question/controller/QuestionController.java
+++ b/server/src/main/java/server/question/controller/QuestionController.java
@@ -103,8 +103,9 @@ public class QuestionController {
     public ResponseEntity<MultiResponseDto<QuestionsResponseDto>> getQuestionsByCategory(@RequestParam String mainCategory,
                                                                                          @RequestParam String subCategory,
                                                                                          @Positive @RequestParam int page,
-                                                                                         @Positive @RequestParam int size) {
-        Page<Question> pageQuestions = questionService.findQuestionsByCategory(mainCategory, subCategory, page - 1, size);
+                                                                                         @Positive @RequestParam int size,
+                                                                                         @RequestParam String sort) {
+        Page<Question> pageQuestions = questionService.findQuestionsByCategory(mainCategory, subCategory, page - 1, size, sort);
         List<Question> questions = pageQuestions.getContent();
 
         return ResponseEntity.ok(new MultiResponseDto<>(questionMapper.questionsToQuestionsResponseDtos(questions, userMapper), pageQuestions));

--- a/server/src/main/java/server/question/repository/QuestionRepository.java
+++ b/server/src/main/java/server/question/repository/QuestionRepository.java
@@ -13,6 +13,7 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
     @Query("update Question q set q.views = :views where q.questionId = :questionId")
     int updateViews(@Param("views") int views, @Param("questionId") long questionId);
     Page<Question> findAllByMainCategory(String mainCategory, Pageable pageable);
+    Page<Question> findAllBySubCategory(String subCategory, Pageable pageable);
     Page<Question> findAllByMainCategoryAndSubCategory(String mainCategory, String subCategory, Pageable pageable);
 
     Page<Question> findByContentContaining(String keyword, Pageable pageable);

--- a/server/src/main/java/server/question/service/QuestionService.java
+++ b/server/src/main/java/server/question/service/QuestionService.java
@@ -60,11 +60,18 @@ public class QuestionService {
         PageRequest pageRequest = PageRequest.of(page, size, sort);
 
         if (mainCategory.equals("all")) {
-            return questionRepository.findAll(pageRequest);
-        } else if (subCategory == null) {
-            return questionRepository.findAllByMainCategory(mainCategory, pageRequest);
+            if (subCategory.equals("all")) {
+                return questionRepository.findAll(pageRequest);
+            } else {
+                return questionRepository.findAllBySubCategory(subCategory, pageRequest);
+            }
         } else {
-            return questionRepository.findAllByMainCategoryAndSubCategory(mainCategory, subCategory, pageRequest);
+            if (subCategory.equals("all")) {
+                return questionRepository.findAllByMainCategory(mainCategory, pageRequest);
+            }
+            else {
+                return questionRepository.findAllByMainCategoryAndSubCategory(mainCategory, subCategory, pageRequest);
+            }
         }
     }
 

--- a/server/src/main/java/server/question/service/QuestionService.java
+++ b/server/src/main/java/server/question/service/QuestionService.java
@@ -54,10 +54,10 @@ public class QuestionService {
         questionRepository.updateViews(views, questionId);
     }
 
-    public Page<Question> findQuestionsByCategory(String mainCategory, String subCategory, int page, int size) {
+    public Page<Question> findQuestionsByCategory(String mainCategory, String subCategory, int page, int size, String sort) {
 
-        Sort sort = Sort.by("questionId").descending();
-        PageRequest pageRequest = PageRequest.of(page, size, sort);
+        Sort sortParm = Sort.by(sort).descending();
+        PageRequest pageRequest = PageRequest.of(page, size, sortParm);
 
         if (mainCategory.equals("all")) {
             if (subCategory.equals("all")) {


### PR DESCRIPTION
### Summary
회의에서 정리된 내용과 같이 메인 페이지 질문 조회 시 카테고리 필터링 및 정렬 방법 변경하였습니다.


### Key Changes 
- 질문 전체 조회 카테고리 필터링 방법 수정
- 전체 질문 조회 정렬 방법을 조회순, 최신순으로 선택할 수 있게 수정함


### To Reviewers
@klkim1913  혹시 수정해야할 코드가 있으면 변경 제안 해주시면 확인 후 적용해서 머지하겠습니다.
@Inhoob  상황 공유차 리뷰어로 추가했습니다. api 명세도 업데이트 해두었으니 머지되면 참고하셔서 테스트해보시면 될 것 같습니다.


### Issue number
#183 #186
