### PR TITLE
refactor: 필드에러와 일반 에러 형식 통일

### DIFF
--- a/server/src/main/java/server/exception/GlobalExceptionAdvice.java
+++ b/server/src/main/java/server/exception/GlobalExceptionAdvice.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
 
 @Slf4j


### PR DESCRIPTION
### Summary
에러처리 반환값 통일화 진행했습니다.


### Key Changes 
필드에러도 아래와 같이 일반 에러와 동일하게 반환되도록 수정했습니다.
그런데 이전에는 필드에러가 다수일 경우 모두 출력하였으나, 수정 후에는 한번에 하나의 필드 에러만 출력하도록 변경하였으니 참고부탁드립니다.
(ex. 이메일, 비밀번호가 모두 형식에 맞지 않게 작성된 경우 이전에는 모두 출력하였으나, 변경 후에는 이메일 또는 비밀번호에 대한 하나의 에러만 나옴)

```json
{
    "status": 400,
    "message": "이메일 형식에 맞지 않습니다."
}
```


### To Reviewers
@klkim1913  혹시 더 깔끔하게 코드를 변경할 수 있는 방법이 있다면, 의견 또는 코드 제안 언제나 환영입니다 !!
@Inhoob 상황 공유를 위해 추가하였으니 참고 부탁드립니다.

### Issue number
관련 이슈 #235 